### PR TITLE
WIP: synthesise Events from Condition transitions

### DIFF
--- a/controllers/events/object.go
+++ b/controllers/events/object.go
@@ -138,6 +138,14 @@ func refFromObjRef(oRef corev1.ObjectReference) objectReference {
 	}
 }
 
+func objRefFromRef(ref objectReference) corev1.ObjectReference {
+	return corev1.ObjectReference{
+		Kind:      ref.Kind,
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+}
+
 func refFromOwner(oRef v1.OwnerReference, namespace string) objectReference {
 	return objectReference{
 		Kind:      lc(oRef.Kind),

--- a/controllers/events/watcher.go
+++ b/controllers/events/watcher.go
@@ -1,0 +1,174 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+)
+
+// Take out watches on individual objects, and notify changes in Conditions back as synthetic Events
+type watchManager struct {
+	sync.Mutex
+	client dynamic.Interface
+	mapper meta.RESTMapper
+
+	watches map[objectReference]*watchInfo
+}
+
+type watchInfo struct {
+	ref       objectReference
+	watch     watch.Interface
+	lastEvent time.Time
+	serial    int
+}
+
+func newWatchManager(kubeClient dynamic.Interface, mapper meta.RESTMapper) *watchManager {
+	return &watchManager{
+		client:  kubeClient,
+		mapper:  mapper,
+		watches: make(map[objectReference]*watchInfo),
+	}
+}
+
+// local interface to insulate from EventWatcher type
+type eventNotifier interface {
+	handleEvent(ctx context.Context, event *corev1.Event) error
+}
+
+func (m *watchManager) watch(obj runtime.Object, ew eventNotifier) error {
+	ma, _ := meta.Accessor(obj)
+	var wi *watchInfo
+	{
+		ref := refFromObject(ma)
+		m.Lock()
+		if _, exists := m.watches[ref]; exists {
+			m.Unlock()
+			return nil
+		}
+		wi = &watchInfo{
+			ref:       ref,
+			lastEvent: time.Now().Add(-defaultRecentWindow), // TODO: maybe this can be done more cleanly
+		}
+		m.watches[ref] = wi
+		m.Unlock()
+	}
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	r, err := m.getResourceInterface(gvk, ma.GetNamespace())
+	if err != nil {
+		return err
+	}
+	listOptions := v1.ListOptions{
+		ResourceVersion: ma.GetResourceVersion(),
+	}
+	wi.watch, err = r.Watch(listOptions)
+	if err != nil {
+		return fmt.Errorf("object watch failed: %w", err)
+	}
+
+	go wi.run(ew)
+
+	return nil
+}
+
+func (m *watchManager) getResourceInterface(gvk schema.GroupVersionKind, ns string) (dynamic.ResourceInterface, error) {
+	mapping, err := m.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, fmt.Errorf("resource mapping failed: %w", err)
+	}
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		return m.client.Resource(mapping.Resource), nil
+	}
+	return m.client.Resource(mapping.Resource).Namespace(ns), nil
+}
+
+func (w *watchInfo) run(ew eventNotifier) {
+	for e := range w.watch.ResultChan() {
+		obj, ok := e.Object.(*unstructured.Unstructured)
+		if !ok {
+			continue
+		}
+		_ = w.checkConditionUpdates(obj, ew)
+	}
+}
+
+// Given an object, walk through all its conditions and notify any new ones as Events
+func (w *watchInfo) checkConditionUpdates(obj *unstructured.Unstructured, ew eventNotifier) error {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return nil
+	}
+
+	var latest time.Time
+	for _, conditionUncast := range conditions {
+		condition, ok := conditionUncast.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Check if this condition changed since last time we looked
+		lastTransitionStr, found, err := unstructured.NestedString(condition, "lastTransitionTime")
+		if !found || err != nil {
+			continue
+		}
+		lastTransitionTime, err := time.Parse(time.RFC3339, lastTransitionStr)
+		if err != nil {
+			continue
+		}
+		if !lastTransitionTime.After(w.lastEvent) {
+			continue
+		}
+
+		w.serial++
+
+		name, _, _ := unstructured.NestedString(condition, "type")
+		status, _, _ := unstructured.NestedString(condition, "status")
+		message, _, _ := unstructured.NestedString(condition, "message")
+		reason, _, _ := unstructured.NestedString(condition, "reason")
+
+		// See if we can find a managedFields entry for this condition
+		source, operation, _ := getUpdateSource(obj, "f:status", "f:conditions", `k:{"type":"`+name+`"}`)
+		if reason == "" {
+			reason = operation
+		}
+
+		// synthesise an Event which we will use to generate a Span with all relevant information
+		event := corev1.Event{
+			ObjectMeta: v1.ObjectMeta{
+				UID: types.UID(fmt.Sprintf("%s-%d", w.ref.Name, w.serial)),
+			},
+			Source: corev1.EventSource{
+				Component: source,
+			},
+			EventTime:      v1.NewMicroTime(lastTransitionTime),
+			Type:           name + " " + status,
+			InvolvedObject: objRefFromRef(w.ref),
+			Message:        message,
+			Reason:         reason,
+		}
+
+		err = ew.handleEvent(context.TODO(), &event)
+		if err != nil {
+			continue
+		}
+
+		if lastTransitionTime.After(latest) {
+			latest = lastTransitionTime
+		}
+	}
+	w.lastEvent = latest
+	return nil
+}


### PR DESCRIPTION
Many objects have Conditions, like these on a Deployment:

```
  conditions:
  - lastTransitionTime: "2021-03-01T17:21:28Z"
    lastUpdateTime: "2021-03-01T17:21:28Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2020-11-24T13:37:06Z"
    lastUpdateTime: "2021-03-10T13:48:40Z"
    message: ReplicaSet "querier-6c88c56bbf" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
```

We can create additional spans from the time these conditions are updated. Current code in this PR just creates zero-length spans same as we get with Events, but even better if we could put the start and end time of the span at the points where the transition goes to False then to True.

It works by starting a `Watch()` on any object we received an Event from.
Still to do: drop the watch on objects that haven't done anything in a while.