### PR TITLE
Set the end time of spans 

### DIFF
--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -125,6 +125,16 @@ func eventToSpanID(event *corev1.Event) trace.SpanID {
 	return h
 }
 
+// If time has zero ms, and is close to wall-clock time, use wall-clock time
+func adjustEventTime(event *corev1.Event, now time.Time) {
+	if event.LastTimestamp.Time.IsZero() {
+		return
+	}
+	if event.LastTimestamp.Time.Nanosecond() == 0 && now.Sub(event.LastTimestamp.Time) < time.Second {
+		event.LastTimestamp.Time = now
+	}
+}
+
 // Some events have just an EventTime; if LastTimestamp is present we prefer that.
 func eventTime(event *corev1.Event) time.Time {
 	if !event.LastTimestamp.Time.IsZero() {

--- a/controllers/events/event_controller.go
+++ b/controllers/events/event_controller.go
@@ -84,6 +84,8 @@ func (r *EventWatcher) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Bump Prometheus metrics
 	totalEventsNum.WithLabelValues(event.Type, event.InvolvedObject.Kind, event.Reason).Inc()
 
+	adjustEventTime(&event, time.Now())
+
 	err := r.handleEvent(ctx, &event)
 	if err != nil {
 		log.Error(err, "unable to handle event")

--- a/controllers/events/event_controller.go
+++ b/controllers/events/event_controller.go
@@ -36,6 +36,7 @@ type EventWatcher struct {
 	recent    *recentInfoStore
 	pending   []*corev1.Event
 	resources map[source]*resource.Resource
+	outgoing  *outgoing
 }
 
 // Info about the source of an event, e.g. kubelet
@@ -165,15 +166,10 @@ func (r *EventWatcher) emitSpanFromEvent(ctx context.Context, log logr.Logger, e
 
 	// Send out a span from the event details
 	span := r.eventToSpan(event, remoteContext)
-	r.emitSpan(ctx, span)
+	r.emitSpan(ctx, ref.object, span)
 	r.recent.store(ref, remoteContext, span.SpanContext)
 
 	return true, nil
-}
-
-func (r *EventWatcher) emitSpan(ctx context.Context, span *tracesdk.SpanData) {
-	// TODO: consider building up all the spans then sending in one go
-	r.Exporter.ExportSpans(ctx, []*tracesdk.SpanData{span})
 }
 
 func (r *EventWatcher) getResource(s source) *resource.Resource {
@@ -254,7 +250,7 @@ func (r *EventWatcher) makeSpanContextFromObject(ctx context.Context, obj runtim
 		if err != nil {
 			return noTrace, err
 		}
-		r.emitSpan(ctx, spanData)
+		r.emitSpan(ctx, ref.object, spanData)
 		r.recent.store(ref, noTrace, spanData.SpanContext)
 		return spanData.SpanContext, nil
 	}
@@ -270,6 +266,7 @@ func (r *EventWatcher) runTicker() {
 			r.Log.Error(err, "from checkOlderPending")
 		}
 		r.recent.expire()
+		r.flushOutgoing(context.Background(), time.Now().Add(-2*r.recent.recentWindow))
 	}
 }
 
@@ -278,6 +275,7 @@ func (r *EventWatcher) initialize() {
 	r.startTime = time.Now()
 	r.recent = newRecentInfoStore()
 	r.resources = make(map[source]*resource.Resource)
+	r.outgoing = newOutgoing()
 	r.Unlock()
 	go r.runTicker()
 }

--- a/controllers/events/event_controller_test.go
+++ b/controllers/events/event_controller_test.go
@@ -42,8 +42,8 @@ func TestDeploymentRolloutWithManagedFields(t *testing.T) {
 				"5: kubelet Pod.Created (2) Created container hello-world",
 				"6: kubelet Pod.Started (2) Started container hello-world",
 				"7: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set hello-world-7ff854f459 to 0",
-				"8: kubelet Pod.Killing (7) Stopping container hello-world",
-				"9: replicaset-controller ReplicaSet.SuccessfulDelete (7) Deleted pod: hello-world-7ff854f459-kl4hq",
+				"8: replicaset-controller ReplicaSet.SuccessfulDelete (7) Deleted pod: hello-world-7ff854f459-kl4hq",
+				"9: kubelet Pod.Killing (7) Stopping container hello-world",
 			},
 		},
 		{
@@ -52,14 +52,14 @@ func TestDeploymentRolloutWithManagedFields(t *testing.T) {
 			wantTraces: []string{
 				"0: kubectl deployment.Update ",
 				"1: deployment-controller Deployment.ScalingReplicaSet (0) Scaled up replica set hello-world-6b9d85fbd6 to 1",
-				"2: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set hello-world-7ff854f459 to 0",
-				"3: replicaset-controller ReplicaSet.SuccessfulCreate (1) Created pod: hello-world-6b9d85fbd6-klpv2",
-				"4: default-scheduler Pod.Scheduled (3) Successfully assigned default/hello-world-6b9d85fbd6-klpv2 to kind-control-plane",
-				"5: kubelet Pod.Pulled (3) Container image \"nginx:1.19.2-alpine\" already present on machine",
-				"6: kubelet Pod.Created (3) Created container hello-world",
-				"7: kubelet Pod.Started (3) Started container hello-world",
-				"8: kubelet Pod.Killing (2) Stopping container hello-world",
-				"9: replicaset-controller ReplicaSet.SuccessfulDelete (2) Deleted pod: hello-world-7ff854f459-kl4hq",
+				"2: replicaset-controller ReplicaSet.SuccessfulCreate (1) Created pod: hello-world-6b9d85fbd6-klpv2",
+				"3: default-scheduler Pod.Scheduled (2) Successfully assigned default/hello-world-6b9d85fbd6-klpv2 to kind-control-plane",
+				"4: kubelet Pod.Pulled (2) Container image \"nginx:1.19.2-alpine\" already present on machine",
+				"5: kubelet Pod.Created (2) Created container hello-world",
+				"6: kubelet Pod.Started (2) Started container hello-world",
+				"7: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set hello-world-7ff854f459 to 0",
+				"8: replicaset-controller ReplicaSet.SuccessfulDelete (7) Deleted pod: hello-world-7ff854f459-kl4hq",
+				"9: kubelet Pod.Killing (7) Stopping container hello-world",
 			},
 		},
 	}
@@ -77,6 +77,7 @@ func TestDeploymentRolloutWithManagedFields(t *testing.T) {
 				g.Expect(r.handleEvent(ctx, &event)).To(o.Succeed())
 			}
 			g.Expect(r.checkOlderPending(ctx, threshold)).To(o.Succeed())
+			r.flushOutgoing(ctx, threshold)
 			g.Expect(exporter.dump()).To(o.Equal(tt.wantTraces))
 		})
 	}
@@ -113,23 +114,23 @@ func Test2PodDeploymentRollout(t *testing.T) {
 				"1: deployment-controller Deployment.ScalingReplicaSet (0) Scaled up replica set bryan-podinfo-5c5df9754b to 1",
 				"2: replicaset-controller ReplicaSet.SuccessfulCreate (1) Created pod: bryan-podinfo-5c5df9754b-4w2hj",
 				"3: default-scheduler Pod.Scheduled (2) Successfully assigned default/bryan-podinfo-5c5df9754b-4w2hj to kind-control-plane",
-				"4: replicaset-controller ReplicaSet.SuccessfulDelete (0) Deleted pod: bryan-podinfo-787c9986b5-tkd9p",
-				"5: kubelet Pod.Killing (4) Stopping container podinfod",
-				"6: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set bryan-podinfo-787c9986b5 to 1",
-				"7: deployment-controller Deployment.ScalingReplicaSet (0) Scaled up replica set bryan-podinfo-5c5df9754b to 2",
-				"8: replicaset-controller ReplicaSet.SuccessfulCreate (7) Created pod: bryan-podinfo-5c5df9754b-bhj4w",
-				"9: default-scheduler Pod.Scheduled (8) Successfully assigned default/bryan-podinfo-5c5df9754b-bhj4w to kind-control-plane",
-				"10: kubelet Pod.Pulling (2) Pulling image \"ghcr.io/stefanprodan/podinfo:5.0.3\"",
-				"11: kubelet Pod.Pulling (8) Pulling image \"ghcr.io/stefanprodan/podinfo:5.0.3\"",
-				"12: kubelet Pod.Pulled (2) Successfully pulled image \"ghcr.io/stefanprodan/podinfo:5.0.3\" in 7.556422631s",
-				"13: kubelet Pod.Created (2) Created container podinfod",
-				"14: kubelet Pod.Started (2) Started container podinfod",
-				"15: kubelet Pod.Pulled (8) Successfully pulled image \"ghcr.io/stefanprodan/podinfo:5.0.3\" in 8.129591184s",
-				"16: kubelet Pod.Created (8) Created container podinfod",
-				"17: kubelet Pod.Started (8) Started container podinfod",
-				"18: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set bryan-podinfo-787c9986b5 to 0",
-				"19: kubelet Pod.Killing (4) Stopping container podinfod", // Ideally this would come after 20
-				"20: replicaset-controller ReplicaSet.SuccessfulDelete (18) Deleted pod: bryan-podinfo-787c9986b5-fws9t",
+				"4: kubelet Pod.Pulling (2) Pulling image \"ghcr.io/stefanprodan/podinfo:5.0.3\"",
+				"5: kubelet Pod.Pulled (2) Successfully pulled image \"ghcr.io/stefanprodan/podinfo:5.0.3\" in 7.556422631s",
+				"6: kubelet Pod.Created (2) Created container podinfod",
+				"7: kubelet Pod.Started (2) Started container podinfod",
+				"8: replicaset-controller ReplicaSet.SuccessfulDelete (0) Deleted pod: bryan-podinfo-787c9986b5-tkd9p",
+				"9: kubelet Pod.Killing (8) Stopping container podinfod",
+				"10: kubelet Pod.Killing (8) Stopping container podinfod", // Ideally this would come after 20
+				"11: deployment-controller Deployment.ScalingReplicaSet (0) Scaled up replica set bryan-podinfo-5c5df9754b to 2",
+				"12: replicaset-controller ReplicaSet.SuccessfulCreate (11) Created pod: bryan-podinfo-5c5df9754b-bhj4w",
+				"13: default-scheduler Pod.Scheduled (12) Successfully assigned default/bryan-podinfo-5c5df9754b-bhj4w to kind-control-plane",
+				"14: kubelet Pod.Pulling (12) Pulling image \"ghcr.io/stefanprodan/podinfo:5.0.3\"",
+				"15: kubelet Pod.Pulled (12) Successfully pulled image \"ghcr.io/stefanprodan/podinfo:5.0.3\" in 8.129591184s",
+				"16: kubelet Pod.Created (12) Created container podinfod",
+				"17: kubelet Pod.Started (12) Started container podinfod",
+				"18: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set bryan-podinfo-787c9986b5 to 1",
+				"19: deployment-controller Deployment.ScalingReplicaSet (0) Scaled down replica set bryan-podinfo-787c9986b5 to 0",
+				"20: replicaset-controller ReplicaSet.SuccessfulDelete (19) Deleted pod: bryan-podinfo-787c9986b5-fws9t",
 			},
 		},
 	}
@@ -147,6 +148,7 @@ func Test2PodDeploymentRollout(t *testing.T) {
 				g.Expect(r.handleEvent(ctx, &event)).To(o.Succeed())
 			}
 			g.Expect(r.checkOlderPending(ctx, threshold)).To(o.Succeed())
+			r.flushOutgoing(ctx, threshold)
 			g.Expect(exporter.dump()).To(o.Equal(tt.wantTraces))
 		})
 	}
@@ -187,6 +189,9 @@ func TestDeploymentRolloutFromFlux(t *testing.T) {
 			},
 		},
 	}
+	threshold, err := time.Parse(time.RFC3339, fluxDeploymentUpdateEventsThresholdStr)
+	g.Expect(err).NotTo(o.HaveOccurred())
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, r, exporter, _ := newTestEventWatcher(&deploy1, &rs1, &rs2, &pod1)
@@ -196,6 +201,8 @@ func TestDeploymentRolloutFromFlux(t *testing.T) {
 				mustParse(t, fluxDeploymentUpdateEvents[index], &event)
 				g.Expect(r.handleEvent(ctx, &event)).To(o.Succeed())
 			}
+			g.Expect(r.checkOlderPending(ctx, threshold)).To(o.Succeed())
+			r.flushOutgoing(ctx, threshold)
 			g.Expect(exporter.dump()).To(o.Equal(tt.wantTraces))
 		})
 	}
@@ -239,6 +246,9 @@ func TestStsRolloutFromFlux(t *testing.T) {
 			},
 		},
 	}
+	threshold, err := time.Parse(time.RFC3339, stsUpdateEventsThresholdStr)
+	g.Expect(err).NotTo(o.HaveOccurred())
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, r, exporter, _ := newTestEventWatcher(&sts1, &pod2, &pod3)
@@ -248,6 +258,8 @@ func TestStsRolloutFromFlux(t *testing.T) {
 				mustParse(t, stsUpdateEvents[index], &event)
 				g.Expect(r.handleEvent(ctx, &event)).To(o.Succeed())
 			}
+			g.Expect(r.checkOlderPending(ctx, threshold)).To(o.Succeed())
+			r.flushOutgoing(ctx, threshold)
 			g.Expect(exporter.dump()).To(o.Equal(tt.wantTraces))
 		})
 	}

--- a/controllers/events/fixtures_test.go
+++ b/controllers/events/fixtures_test.go
@@ -955,6 +955,9 @@ status:
   qosClass: BestEffort
 `
 
+// 2 seconds after the last event time
+const fluxDeploymentUpdateEventsThresholdStr = "2020-12-03T17:53:59Z"
+
 // Events from a Deployment update triggered by Flux; objects have no managedFields
 var fluxDeploymentUpdateEvents = []string{`
   apiVersion: v1

--- a/controllers/events/outgoing.go
+++ b/controllers/events/outgoing.go
@@ -1,0 +1,74 @@
+package events
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	tracesdk "go.opentelemetry.io/otel/sdk/export/trace"
+)
+
+type outgoing struct {
+	sync.Mutex
+
+	byRef    map[objectReference]*tracesdk.SpanData
+	bySpanID map[apitrace.SpanID]*tracesdk.SpanData
+}
+
+func newOutgoing() *outgoing {
+	return &outgoing{
+		byRef:    make(map[objectReference]*tracesdk.SpanData),
+		bySpanID: make(map[apitrace.SpanID]*tracesdk.SpanData),
+	}
+}
+
+const timeFmt = "15:04:05.000"
+
+func (r *EventWatcher) emitSpan(ctx context.Context, ref objectReference, span *tracesdk.SpanData) {
+	r.Log.Info("adding span", "ref", ref, "name", span.Name, "start", span.StartTime.Format(timeFmt), "end", span.EndTime.Format(timeFmt))
+	r.outgoing.Lock()
+	defer r.outgoing.Unlock()
+
+	if prev, found := r.outgoing.byRef[ref]; found {
+		if !prev.StartTime.After(span.StartTime) {
+			prev.EndTime = span.StartTime
+		} else {
+			r.Log.Info("New span before old span", "oldSpan", prev.Name, "oldTime", prev.StartTime.Format(timeFmt), "newSpan", span.Name, "newTime", span.StartTime.Format(timeFmt))
+		}
+		r.Log.Info("emitting span", "ref", ref, "name", prev.Name)
+		r.Exporter.ExportSpans(ctx, []*tracesdk.SpanData{prev})
+		// We do not remove from bySpanID at this time, in case it is needed for parent chains
+	}
+	r.outgoing.byRef[ref] = span
+	r.outgoing.bySpanID[span.SpanContext.SpanID] = span
+
+	for parentID := span.ParentSpanID; parentID.IsValid(); {
+		if parent, found := r.outgoing.bySpanID[parentID]; found {
+			//r.Log.Info("adjusting endtime", "parent", parent.Name, "from", parent.EndTime.Format(timeFmt), "to", span.EndTime.Format(timeFmt))
+			parent.EndTime = span.EndTime
+			parentID = parent.ParentSpanID
+		} else {
+			break
+		}
+	}
+}
+
+func (r *EventWatcher) flushOutgoing(ctx context.Context, threshold time.Time) {
+	r.outgoing.Lock()
+	defer r.outgoing.Unlock()
+	for k, span := range r.outgoing.byRef {
+		if !span.EndTime.After(threshold) {
+			r.Log.Info("deferred emit", "ref", k, "name", span.Name, "endTime", span.EndTime, "threshold", threshold)
+			r.Exporter.ExportSpans(ctx, []*tracesdk.SpanData{span})
+			delete(r.outgoing.byRef, k)
+			delete(r.outgoing.bySpanID, span.SpanContext.SpanID)
+		}
+	}
+	// Now clear out anything old that is still in bySpanID
+	for k, span := range r.outgoing.bySpanID {
+		if !span.EndTime.After(threshold) {
+			delete(r.outgoing.bySpanID, k)
+		}
+	}
+}

--- a/controllers/events/pending.go
+++ b/controllers/events/pending.go
@@ -70,7 +70,7 @@ func (r *EventWatcher) checkOlderPending(ctx context.Context, threshold time.Tim
 		}
 		if success {
 			span := r.eventToSpan(event, remoteContext)
-			r.emitSpan(ctx, span)
+			r.emitSpan(ctx, ref.object, span)
 			r.recent.store(ref, remoteContext, span.SpanContext)
 		}
 	}


### PR DESCRIPTION
Hold outgoing spans, and adjust them to be the length of all of their children.

Also set the end-time of one span to the start-time of the next one for the same object.


To make things look a bit more realistic, we "add back" milliseconds to event times - LastTimestamp is typically reported with zero ms, so we use the time of arrival of the event if that looks close enough.

![image](https://user-images.githubusercontent.com/8125524/111675255-d4739480-8814-11eb-8a08-813b3b10d22a.png)
