### PR TITLE
Increase lint timeout

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
           version: latest
+          args: --timeout=5m
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,16 +13,16 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
           version: latest
           args: --timeout=5m
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
 
     - name: Build
       run: make


### PR DESCRIPTION
I've seen a few PRs time out on lint, which seems to have a timeout around 80 seconds.

Also set up Go before running linter - seems more logical.
