### PR TITLE
Only set recent ref for top-level object if top-level span

### DIFF
--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -25,6 +25,10 @@ func (p actionReference) String() string {
 	return fmt.Sprintf("actor: %s, object: %s", p.actor, p.object) // TODO improve this
 }
 
+func (p actionReference) IsTopLevel() bool {
+	return p.actor.Blank()
+}
+
 // look for the string 'marker' in 'message' and return the following space-separated word.
 // if anything goes wrong, return an empty string.
 func extractWordAfter(message, marker string) string {

--- a/controllers/events/object.go
+++ b/controllers/events/object.go
@@ -32,6 +32,10 @@ func (r objectReference) String() string {
 	return fmt.Sprintf("%s:%s/%s", r.Kind, r.Namespace, r.Name)
 }
 
+func (r objectReference) Blank() bool {
+	return r == objectReference{}
+}
+
 // Given an object, come up with some source for the change, and the time it happened
 func getUpdateSource(obj v1.Object, subFields ...string) (source string, operation string, ts time.Time) {
 	// If it has managed fields, return the newest change that updated the spec

--- a/controllers/events/pending.go
+++ b/controllers/events/pending.go
@@ -71,7 +71,9 @@ func (r *EventWatcher) checkOlderPending(ctx context.Context, threshold time.Tim
 		if success {
 			span := r.eventToSpan(event, remoteContext)
 			r.emitSpan(ctx, ref.object, span)
-			r.recent.store(ref, remoteContext, span.SpanContext)
+			if !(ref.IsTopLevel() && remoteContext.HasSpanID()) { // Only store for top-level object if top-level span
+				r.recent.store(ref, remoteContext, span.SpanContext)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Otherwise each new event for that object is parented off the one before.