### PR TITLE
Stop lowercasing Kubernetes Kind strings

### DIFF
--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -62,7 +62,7 @@ func objectFromEvent(ctx context.Context, client client.Client, event *corev1.Ev
 			break
 		}
 		ret.actor = ret.object
-		ret.object = objectReference{Kind: "replicaset", Namespace: lc(ret.object.Namespace), Name: lc(name)}
+		ret.object = objectReference{Kind: "ReplicaSet", Namespace: lc(ret.object.Namespace), Name: lc(name)}
 	case event.Source.Component == "replicaset-controller" && event.InvolvedObject.Kind == "ReplicaSet":
 		// if we have a message like "Created pod: foo-5c5df9754b-4w2hj"; extract the Pod name
 		name := extractWordAfter(event.Message, "pod: ")
@@ -70,7 +70,7 @@ func objectFromEvent(ctx context.Context, client client.Client, event *corev1.Ev
 			break
 		}
 		ret.actor = ret.object
-		ret.object = objectReference{Kind: "pod", Namespace: lc(ret.object.Namespace), Name: lc(name)}
+		ret.object = objectReference{Kind: "Pod", Namespace: lc(ret.object.Namespace), Name: lc(name)}
 		apiVersion = "v1"
 	case event.Source.Component == "statefulset-controller" && event.InvolvedObject.Kind == "StatefulSet":
 		// if we have a message like "create Pod ingester-3 in StatefulSet ingester successful"; extract the Pod name
@@ -79,7 +79,7 @@ func objectFromEvent(ctx context.Context, client client.Client, event *corev1.Ev
 			break
 		}
 		ret.actor = ret.object
-		ret.object = objectReference{Kind: "pod", Namespace: lc(ret.object.Namespace), Name: lc(name)}
+		ret.object = objectReference{Kind: "Pod", Namespace: lc(ret.object.Namespace), Name: lc(name)}
 		apiVersion = "v1"
 	}
 

--- a/controllers/events/event_controller_test.go
+++ b/controllers/events/event_controller_test.go
@@ -176,7 +176,7 @@ func TestDeploymentRolloutFromFlux(t *testing.T) {
 			name: "flux-event-later",
 			perm: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			wantTraces: []string{
-				"0: flux deployment.Sync Commit e332e7bac962: Update nginx",
+				"0: flux Deployment.Sync Commit e332e7bac962: Update nginx",
 				"1: deployment-controller Deployment.ScalingReplicaSet (0) Scaled up replica set hello-world-f77b4f6c8 to 1",
 				"2: replicaset-controller ReplicaSet.SuccessfulCreate (1) Created pod: hello-world-f77b4f6c8-6tcj2",
 				"3: default-scheduler Pod.Scheduled (2) Successfully assigned default/hello-world-f77b4f6c8-6tcj2 to node2",
@@ -228,7 +228,7 @@ func TestStsRolloutFromFlux(t *testing.T) {
 			name: "flux-sts",
 			perm: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14},
 			wantTraces: []string{
-				"0: flux statefulset.Sync Commit fc4e825b46ac: Update ingester to latest, in dev",
+				"0: flux StatefulSet.Sync Commit fc4e825b46ac: Update ingester to latest, in dev",
 				"1: statefulset-controller StatefulSet.SuccessfulDelete (0) delete Pod ingester-3 in StatefulSet ingester successful",
 				"2: kubelet Pod.Killing (1) Stopping container ingester",
 				"3: statefulset-controller StatefulSet.SuccessfulCreate (0) create Pod ingester-3 in StatefulSet ingester successful",

--- a/controllers/events/fixtures_test.go
+++ b/controllers/events/fixtures_test.go
@@ -1050,7 +1050,7 @@ var fluxDeploymentUpdateEvents = []string{`
   firstTimestamp: "2020-12-03T17:53:52Z"
   involvedObject:
     apiVersion: apps/v1
-    kind: deployment
+    kind: Deployment
     name: hello-world
     namespace: default
   kind: Event
@@ -3543,7 +3543,7 @@ eventTime: null
 firstTimestamp: "2021-02-17T14:20:30Z"
 involvedObject:
   apiVersion: apps/v1
-  kind: statefulset
+  kind: StatefulSet
   name: ingester
   namespace: cortex
 kind: Event

--- a/controllers/events/object.go
+++ b/controllers/events/object.go
@@ -121,14 +121,15 @@ func getObject(ctx context.Context, c client.Client, apiVersion, kind, namespace
 	return obj, errors.Wrap(err, "unable to get object")
 }
 
-// canonicalise strings via lowercase - we see "deployment" vs "Deployment"
+// Canonicalise strings via lowercase - Kubernetes is case-independent.
+// (we don't canonicalise Kind)
 func lc(s string) string {
 	return strings.ToLower(s)
 }
 
 func refFromObjRef(oRef corev1.ObjectReference) objectReference {
 	return objectReference{
-		Kind:      lc(oRef.Kind),
+		Kind:      oRef.Kind,
 		Namespace: lc(oRef.Namespace),
 		Name:      lc(oRef.Name),
 	}
@@ -136,7 +137,7 @@ func refFromObjRef(oRef corev1.ObjectReference) objectReference {
 
 func refFromOwner(oRef v1.OwnerReference, namespace string) objectReference {
 	return objectReference{
-		Kind:      lc(oRef.Kind),
+		Kind:      oRef.Kind,
 		Namespace: lc(namespace),
 		Name:      lc(oRef.Name),
 	}
@@ -145,7 +146,7 @@ func refFromOwner(oRef v1.OwnerReference, namespace string) objectReference {
 func refFromObject(obj v1.Object) objectReference {
 	ty := obj.(v1.Type)
 	return objectReference{
-		Kind:      lc(ty.GetKind()),
+		Kind:      ty.GetKind(),
 		Namespace: lc(obj.GetNamespace()),
 		Name:      lc(obj.GetName()),
 	}


### PR DESCRIPTION
If we keep "Pod" as-is, not "pod", this makes things simpler when mappping to Resource and other things in the Kubiverse.