### PR TITLE
fix: add /pkg sources to fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go mod download
 # Copy the go source
 COPY main.go main.go
 COPY controllers/ controllers/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go


### PR DESCRIPTION
Hi, I've tried to build Docker image of kspan and it fails with the following output:
```
docker build -t kspan:a68cc45 .
Sending build context to Docker daemon  816.6kB
Step 1/13 : FROM golang:1.16.2 as builder
1.16.2: Pulling from library/golang
004f1eed87df: Pull complete 
5d6f1e8117db: Pull complete 
48c2faf66abe: Pull complete 
234b70d0479d: Pull complete 
f5e9f83ff9bc: Pull complete 
abff7ae5ce65: Pull complete 
26b15789ebb1: Pull complete 
Digest: sha256:31447e84d4af01c218cf158072028ada82d49248fd067d1b7228857062aef520
Status: Downloaded newer image for golang:1.16.2
 ---> 217d1e255961
Step 2/13 : WORKDIR /workspace
 ---> Running in eb0ff81ffa62
Removing intermediate container eb0ff81ffa62
 ---> 890d6cbda263
Step 3/13 : COPY go.mod go.mod
 ---> 03a329b1ea40
Step 4/13 : COPY go.sum go.sum
 ---> 9b8106ca3d5f
Step 5/13 : RUN go mod download
 ---> Running in 84e8d9ea1935
Removing intermediate container 84e8d9ea1935
 ---> 17112432e2b6
Step 6/13 : COPY main.go main.go
 ---> cf1203bb17e1
Step 7/13 : COPY controllers/ controllers/
 ---> b8d19feb42ca
Step 8/13 : RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
 ---> Running in 573097dd18a9
controllers/events/event_controller.go:24:2: no required module provides package github.com/weaveworks-experiments/kspan/pkg/mtime; to add it:
	go get github.com/weaveworks-experiments/kspan/pkg/mtime
The command '/bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go' returned a non-zero code: 1
```

I believe this change fixes this in a reasonable way. :)