### PR TITLE
Add support for OTEL default resource attributes

### DIFF
--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -115,6 +115,8 @@ func (r *EventWatcher) eventToSpan(event *corev1.Event, remoteContext trace.Span
 		statusCode = codes.Error
 	}
 
+	attrs = append(attrs, r.Resource.Attributes()...)
+
 	return &tracesdk.SpanSnapshot{
 		SpanContext: trace.NewSpanContext(trace.SpanContextConfig{
 			TraceID: remoteContext.TraceID(),

--- a/controllers/events/event_controller.go
+++ b/controllers/events/event_controller.go
@@ -34,6 +34,7 @@ type EventWatcher struct {
 	Client    client.Client
 	Log       logr.Logger
 	Exporter  tracesdk.SpanExporter
+	Resource  *resource.Resource
 	Capture   io.Writer
 	ticker    *time.Ticker
 	startTime time.Time


### PR DESCRIPTION
This will add support for pulling in opentelemetry's default attributes
It adds sdk information, service.name and discrete key/value entries as
specified on the environment and local host information such as the
hostname and instance.