### PR TITLE
Use OpenTelemetry conventions for some tags.

### DIFF
--- a/controllers/events/event.go
+++ b/controllers/events/event.go
@@ -96,8 +96,7 @@ func (r *EventWatcher) eventToSpan(event *corev1.Event, remoteContext trace.Span
 
 	attrs := []attribute.KeyValue{
 		attribute.String("kind", event.InvolvedObject.Kind),
-		attribute.String("namespace", event.InvolvedObject.Namespace),
-		attribute.String("object", event.InvolvedObject.Name),
+		attribute.String("k8s."+strings.ToLower(event.InvolvedObject.Kind)+".name", event.InvolvedObject.Name),
 	}
 
 	if event.Reason != "" {
@@ -108,6 +107,9 @@ func (r *EventWatcher) eventToSpan(event *corev1.Event, remoteContext trace.Span
 	}
 	if event.Name != "" {
 		attrs = append(attrs, attribute.String("eventID", event.Namespace+"/"+event.Name))
+	}
+	if event.InvolvedObject.Namespace != "" {
+		attrs = append(attrs, attribute.String("k8s.namespace.name", event.InvolvedObject.Namespace))
 	}
 
 	statusCode := codes.Ok

--- a/controllers/events/object.go
+++ b/controllers/events/object.go
@@ -73,9 +73,11 @@ func (r *EventWatcher) createTraceFromTopLevelObject(ctx context.Context, obj ru
 		updateTime = eventTime
 	}
 
+	kind := obj.GetObjectKind().GroupVersionKind().Kind
 	attrs := []attribute.KeyValue{
-		attribute.String("namespace", m.GetNamespace()),
-		attribute.String("object", m.GetName()),
+		attribute.String("k8s.namespace.name", m.GetNamespace()),
+		attribute.String("k8s."+strings.ToLower(kind)+".name", m.GetName()),
+		attribute.String("kind", kind),
 		attribute.Int64("generation", m.GetGeneration()),
 	}
 


### PR DESCRIPTION
Resolves #46.  I think this is what @pavolloffay asked for.

`k8s.namespace.name` instead of `namespace`, and `k8s.pod.name`, `k8s.job.name`, etc., instead of `object`.

Also omit the namespace tag if it is blank, e.g. for a Node, and add the `kind` for a top-level object.

![image](https://user-images.githubusercontent.com/8125524/145620724-327f2c81-4571-41df-be48-f648362c160d.png)
